### PR TITLE
Automated version insertion in javadoc

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -11,7 +11,8 @@ release:
   script: |
     mvn versions:set "-DnewVersion=${tag}"
     git commit -am "${tag}"
-    mvn clean deploy --settings /home/r/settings.xml -Psonatype -Pjcabi-gpg -Procollections
+    mvn clean deploy --settings /home/r/settings.xml -Psonatype -Pjcabi-gpg
+    -Procollections -Ptendiwa-version
   commanders:
   - suseika
 deploy:

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,33 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>tendiwa-javadoc-version</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includes>
+                        <include>${project.basedir}/src/main/java/**</include>
+                        <include>${project.basedir}/src/test/java/**</include>
+                    </includes>
+                    <replacements>
+                        <replacement>
+                            <!-- replace "$tendiwa-version$" with current project version -->
+                            <value>\u0024tendiwa-version\u0024</value>
+                            <token>${project.version}</token>
+                        </replacement>
+                    </replacements>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/src/main/java/org/tendiwa/rocollections/ReadOnlyCollection.java
+++ b/src/main/java/org/tendiwa/rocollections/ReadOnlyCollection.java
@@ -30,7 +30,8 @@ import java.util.stream.Stream;
  *
  * @param <T> Type of elements of the collection.
  * @author Georgy Vlasov (suseika@tendiwa.org)
- * @version $Id$
+ * @version $tendiwa-version$
+ * @since 0.1
  */
 public interface ReadOnlyCollection<T> extends Iterable<T> {
     /**

--- a/src/main/java/org/tendiwa/rocollections/ReadOnlyList.java
+++ b/src/main/java/org/tendiwa/rocollections/ReadOnlyList.java
@@ -27,7 +27,8 @@ package org.tendiwa.rocollections;
  * A list with only accessors and no mutators.
  *
  * @author Georgy Vlasov (suseika@tendiwa.org)
- * @version $Id$
+ * @version $tendiwa-version$
+ * @since 0.1
  */
 public interface ReadOnlyList<T> extends ReadOnlyCollection<T> {
     /**

--- a/src/main/java/org/tendiwa/rocollections/ReadOnlySet.java
+++ b/src/main/java/org/tendiwa/rocollections/ReadOnlySet.java
@@ -28,7 +28,8 @@ package org.tendiwa.rocollections;
  *
  * @param <T> Type of elements of the set.
  * @author Georgy Vlasov (suseika@tendiwa.org)
- * @version $Id$
+ * @version $tendiwa-version$
+ * @since 0.1
  */
 public interface ReadOnlySet<T> extends ReadOnlyCollection<T> {
     /**

--- a/src/main/java/org/tendiwa/rocollections/WrappingReadOnlyCollection.java
+++ b/src/main/java/org/tendiwa/rocollections/WrappingReadOnlyCollection.java
@@ -31,7 +31,8 @@ import java.util.stream.Stream;
  * Wraps a {@link java.util.Collection} to expose only its accessors.
  *
  * @author Georgy Vlasov (suseika@tendiwa.org)
- * @version $Id$
+ * @version $tendiwa-version$
+ * @since 0.1
  */
 class WrappingReadOnlyCollection<T> implements ReadOnlyCollection<T> {
     /**

--- a/src/main/java/org/tendiwa/rocollections/WrappingReadOnlyList.java
+++ b/src/main/java/org/tendiwa/rocollections/WrappingReadOnlyList.java
@@ -31,7 +31,8 @@ import java.util.stream.Stream;
  * Wraps a {@link java.util.List} to expose only its accessors.
  *
  * @author Georgy Vlasov (suseika@tendiwa.org)
- * @version $Id$
+ * @version $tendiwa-version$
+ * @since 0.1
  */
 public class WrappingReadOnlyList<T> implements ReadOnlyList<T> {
     /**

--- a/src/main/java/org/tendiwa/rocollections/WrappingReadOnlySet.java
+++ b/src/main/java/org/tendiwa/rocollections/WrappingReadOnlySet.java
@@ -32,7 +32,8 @@ import java.util.stream.Stream;
  *
  * @param <T> Type of elements of the collection.
  * @author Georgy Vlasov (suseika@tendiwa.org)
- * @version $Id$
+ * @version $tendiwa-version$
+ * @since 0.1
  */
 @SuppressWarnings("unused")
 public class WrappingReadOnlySet<T> implements ReadOnlySet<T> {

--- a/src/main/java/org/tendiwa/rocollections/test/base/AbstractReadOnlyCollectionTest.java
+++ b/src/main/java/org/tendiwa/rocollections/test/base/AbstractReadOnlyCollectionTest.java
@@ -35,7 +35,8 @@ import org.tendiwa.rocollections.ReadOnlyCollection;
  * A base test for {@link ReadOnlyCollection}s.
  *
  * @author Georgy Vlasov (suseika@tendiwa.org)
- * @version $Id$
+ * @version $tendiwa-version$
+ * @since 0.1
  */
 public abstract class AbstractReadOnlyCollectionTest<T> {
     /**

--- a/src/main/java/org/tendiwa/rocollections/test/base/AbstractReadOnlyListTest.java
+++ b/src/main/java/org/tendiwa/rocollections/test/base/AbstractReadOnlyListTest.java
@@ -31,7 +31,8 @@ import org.tendiwa.rocollections.ReadOnlyList;
  * A base test for {@link ReadOnlyList}s.
  *
  * @author Georgy Vlasov (suseika@tendiwa.org)
- * @version $Id$
+ * @version $tendiwa-version$
+ * @since 0.1
  */
 public abstract class AbstractReadOnlyListTest<T> extends
     AbstractReadOnlyCollectionTest<T> {

--- a/src/main/java/org/tendiwa/rocollections/test/base/package-info.java
+++ b/src/main/java/org/tendiwa/rocollections/test/base/package-info.java
@@ -26,6 +26,6 @@
  * Base tests for ReadOnlyCollections.
  *
  * @author Georgy Vlasov (suseika@tendiwa.org)
- * @version $Id$
+ * @version $tendiwa-version$
  */
 package org.tendiwa.rocollections.test.base;

--- a/src/test/java/org/tendiwa/rocollections/WrappingReadOnlyListTest.java
+++ b/src/test/java/org/tendiwa/rocollections/WrappingReadOnlyListTest.java
@@ -34,7 +34,8 @@ import org.tendiwa.rocollections.test.base.AbstractReadOnlyListTest;
  * passed into that static method.
  *
  * @author Georgy Vlasov (suseika@tendiwa.org)
- * @version $Id$
+ * @version $tendiwa-version$
+ * @since 0.1
  */
 @RunWith(Enclosed.class)
 public final class WrappingReadOnlyListTest {


### PR DESCRIPTION
I configure automated version insertion in javadoc with `replacer` Maven plugin. For that I introduces a `$tendiwa-version$` value for `@version` tag in javadoc that will be replaced with `${project.version}` during Maven build.
